### PR TITLE
Surface.SortByOrientation added

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 
 *.db
+*.backup

--- a/nodes/0.7.x/Surface.SortByOrientation(normalZ).dyf
+++ b/nodes/0.7.x/Surface.SortByOrientation(normalZ).dyf
@@ -1,0 +1,82 @@
+<Workspace Version="0.7.5.3566" X="342.418910309099" Y="194.135957798838" zoom="0.803321593462598" Description="Sorts (Sur)Faces in three lists each containing the (Sur)Faces with normals pointing up (z=1), down (z=-1) or horizontal (z=0)." Category="Clockwork.Geometry.Surface.Actions" Name="Surface.SortByOrientation(normalZ)" ID="fa47dbf7-bb14-4f81-b318-e08a9f8ac341">
+  <Elements>
+    <Dynamo.Nodes.DSFunction type="Dynamo.Nodes.DSFunction" guid="e73bd2e2-bf74-481f-be79-de2c8b4cec02" nickname="Surface.NormalAtParameter" x="458.156346810544" y="131.734822553759" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Surface.NormalAtParameter@double,double">
+      <PortInfo index="1" default="True" />
+      <PortInfo index="2" default="True" />
+    </Dynamo.Nodes.DSFunction>
+    <Dynamo.Nodes.DSFunction type="Dynamo.Nodes.DSFunction" guid="3073f344-8751-4c58-9055-a0997f61b196" nickname="Vector.Z" x="688.153007490744" y="158.070318051492" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Vector.Z" />
+    <Dynamo.Nodes.CodeBlockNodeModel type="Dynamo.Nodes.CodeBlockNodeModel" guid="c2f39655-e13a-4278-81d2-ee9bf7f762c7" nickname="Code Block" x="745.017868753733" y="246.242924865393" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="1;" ShouldFocus="false" />
+    <DSIronPythonNode.PythonNode type="DSIronPythonNode.PythonNode" guid="924659e5-055c-45ed-8003-8dd0015f413a" nickname="Python Script" x="878.72130781573" y="158.948167901416" isVisible="true" isUpstreamVisible="true" lacing="Disabled" inputcount="2">
+      <Script>import clr
+clr.AddReference('ProtoGeometry')
+from Autodesk.DesignScript.Geometry import *
+#The inputs to this node will be stored as a list in the IN variable.
+list = IN[0]
+key = IN[1]
+
+bools = []
+#Assign your output to the OUT variable
+for item in list:
+	if item == key:
+		bools += [True]
+	else:
+		bools += [False]
+OUT = bools</Script>
+    </DSIronPythonNode.PythonNode>
+    <Dynamo.Nodes.DSFunction type="Dynamo.Nodes.DSFunction" guid="44fcb2f8-a76f-49e3-a568-1fbe90b7cc1e" nickname="List.FilterByBoolMask" x="1063.94762614979" y="89.5980297573862" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="DSCoreNodes.dll" function="DSCore.List.FilterByBoolMask@var[]..[],var[]..[]" />
+    <Dynamo.Nodes.DSFunction type="Dynamo.Nodes.DSFunction" guid="18e05e10-6336-4bf1-86eb-3a118548ae9d" nickname="Surface.NormalAtParameter" x="1229.8612477855" y="262.534450192499" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Surface.NormalAtParameter@double,double">
+      <PortInfo index="1" default="True" />
+      <PortInfo index="2" default="True" />
+    </Dynamo.Nodes.DSFunction>
+    <Dynamo.Nodes.CodeBlockNodeModel type="Dynamo.Nodes.CodeBlockNodeModel" guid="7d8b08c9-baa3-436c-8d9b-e3c4bbf9382f" nickname="Code Block" x="1519.10456437178" y="354.657449811217" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="-1;" ShouldFocus="false" />
+    <Dynamo.Nodes.DSFunction type="Dynamo.Nodes.DSFunction" guid="dbc0f0a7-3627-4c6c-be57-b3720bebbf6e" nickname="Vector.Z" x="1456.54105967697" y="261.976107159691" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Vector.Z" />
+    <DSIronPythonNode.PythonNode type="DSIronPythonNode.PythonNode" guid="12d2a557-a88b-4a46-8221-28fb4bbc3373" nickname="Python Script" x="1635.22374476865" y="299.55725541626" isVisible="true" isUpstreamVisible="true" lacing="Disabled" inputcount="2">
+      <Script>import clr
+clr.AddReference('ProtoGeometry')
+from Autodesk.DesignScript.Geometry import *
+#The inputs to this node will be stored as a list in the IN variable.
+list = IN[0]
+key = IN[1]
+
+bools = []
+#Assign your output to the OUT variable
+for item in list:
+	if item == key:
+		bools += [True]
+	else:
+		bools += [False]
+OUT = bools</Script>
+    </DSIronPythonNode.PythonNode>
+    <Dynamo.Nodes.DSFunction type="Dynamo.Nodes.DSFunction" guid="d4053e23-7cf8-496d-8d22-c5503cad5f64" nickname="List.FilterByBoolMask" x="1852.21561783822" y="6.81709332711711" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="DSCoreNodes.dll" function="DSCore.List.FilterByBoolMask@var[]..[],var[]..[]" />
+    <Dynamo.Nodes.Symbol type="Dynamo.Nodes.Symbol" guid="20c6f45c-db12-45ea-bfc1-b5e5ea9047c9" nickname="Input" x="290.045732488888" y="1.2448314699094" isVisible="true" isUpstreamVisible="true" lacing="Disabled">
+      <Symbol value="Face[]" />
+    </Dynamo.Nodes.Symbol>
+    <Dynamo.Nodes.Output type="Dynamo.Nodes.Output" guid="db73eaf3-90a7-44eb-b415-50c997d0b728" nickname="Output" x="2071.02867421804" y="85.1632047477744" isVisible="true" isUpstreamVisible="true" lacing="Disabled">
+      <Symbol value="vertical" />
+    </Dynamo.Nodes.Output>
+	<Dynamo.Nodes.Output type="Dynamo.Nodes.Output" guid="1f0aa8ee-6587-4f58-b76d-34447679519d" nickname="Output" x="2075.77644869875" y="172.106824925816" isVisible="true" isUpstreamVisible="true" lacing="Disabled">
+      <Symbol value="horizontalUp" />
+    </Dynamo.Nodes.Output>
+    <Dynamo.Nodes.Output type="Dynamo.Nodes.Output" guid="86aa385d-7a3e-4c3c-9e90-8cfb61cc68c9" nickname="Output" x="2074.58950507858" y="15.8753709198813" isVisible="true" isUpstreamVisible="true" lacing="Disabled">
+      <Symbol value="horizontalDown" />
+    </Dynamo.Nodes.Output>
+  </Elements>
+  <Connectors>
+    <Dynamo.Models.ConnectorModel start="e73bd2e2-bf74-481f-be79-de2c8b4cec02" start_index="0" end="3073f344-8751-4c58-9055-a0997f61b196" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="3073f344-8751-4c58-9055-a0997f61b196" start_index="0" end="924659e5-055c-45ed-8003-8dd0015f413a" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="c2f39655-e13a-4278-81d2-ee9bf7f762c7" start_index="0" end="924659e5-055c-45ed-8003-8dd0015f413a" end_index="1" portType="0" />
+    <Dynamo.Models.ConnectorModel start="924659e5-055c-45ed-8003-8dd0015f413a" start_index="0" end="44fcb2f8-a76f-49e3-a568-1fbe90b7cc1e" end_index="1" portType="0" />
+    <Dynamo.Models.ConnectorModel start="44fcb2f8-a76f-49e3-a568-1fbe90b7cc1e" start_index="0" end="1f0aa8ee-6587-4f58-b76d-34447679519d" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="44fcb2f8-a76f-49e3-a568-1fbe90b7cc1e" start_index="1" end="18e05e10-6336-4bf1-86eb-3a118548ae9d" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="18e05e10-6336-4bf1-86eb-3a118548ae9d" start_index="0" end="dbc0f0a7-3627-4c6c-be57-b3720bebbf6e" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="7d8b08c9-baa3-436c-8d9b-e3c4bbf9382f" start_index="0" end="12d2a557-a88b-4a46-8221-28fb4bbc3373" end_index="1" portType="0" />
+    <Dynamo.Models.ConnectorModel start="dbc0f0a7-3627-4c6c-be57-b3720bebbf6e" start_index="0" end="12d2a557-a88b-4a46-8221-28fb4bbc3373" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="12d2a557-a88b-4a46-8221-28fb4bbc3373" start_index="0" end="d4053e23-7cf8-496d-8d22-c5503cad5f64" end_index="1" portType="0" />
+    <Dynamo.Models.ConnectorModel start="d4053e23-7cf8-496d-8d22-c5503cad5f64" start_index="0" end="86aa385d-7a3e-4c3c-9e90-8cfb61cc68c9" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="d4053e23-7cf8-496d-8d22-c5503cad5f64" start_index="1" end="db73eaf3-90a7-44eb-b415-50c997d0b728" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="20c6f45c-db12-45ea-bfc1-b5e5ea9047c9" start_index="0" end="e73bd2e2-bf74-481f-be79-de2c8b4cec02" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="20c6f45c-db12-45ea-bfc1-b5e5ea9047c9" start_index="0" end="44fcb2f8-a76f-49e3-a568-1fbe90b7cc1e" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="20c6f45c-db12-45ea-bfc1-b5e5ea9047c9" start_index="0" end="d4053e23-7cf8-496d-8d22-c5503cad5f64" end_index="0" portType="0" />
+  </Connectors>
+  <Notes />
+</Workspace>


### PR DESCRIPTION
Hey @andydandy74,
I created a node for getting three lists containing surfaces that are either vertical or horizontal and the horizontal ones are devided in normals pointing up and down. I use this node to get the upper, lower and surrounding surfaces of a solid. Added it in Clockwork.Geometry.Surfaces.Actions.
Perhaps you like to add it.
Fabian
