### PR TITLE
Update Element.Name (Universal).py

### DIFF
--- a/nodes/0.7.x/python/Element.Name (Universal).py
+++ b/nodes/0.7.x/python/Element.Name (Universal).py
@@ -2,11 +2,17 @@ import clr
 clr.AddReference('RevitAPI')
 from Autodesk.Revit.DB import *
 
-faminsts = UnwrapElement(IN[0])
+faminsts = IN[0]
 elementlist = list()
 for item in faminsts:
 	try:
-		elementlist.append(item.Name)
+		n = UnwrapElement(item).Name
 	except:
-		elementlist.append(list())
+		n = None
+	if n == None:
+		try:
+			n = item.Name
+		except:
+			n = []
+	elementlist.append(n)
 OUT = elementlist


### PR DESCRIPTION
The node fails for FamilySymbols due to the API's idiosyncrasies. the built-in Dynamo method seems to have a good workaround for this.
![2015-09-01_14-43-17](https://cloud.githubusercontent.com/assets/7148394/9597768/b20c2488-50b7-11e5-9799-1a5b805f016b.png)
 